### PR TITLE
Add dynamic section headers for CollectionView in TopicViewController

### DIFF
--- a/labs-ios-starter.xcodeproj/project.pbxproj
+++ b/labs-ios-starter.xcodeproj/project.pbxproj
@@ -33,7 +33,8 @@
 		1D4D9C0A25092B5400348246 /* labs_ios_starterUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4D9C0925092B5400348246 /* labs_ios_starterUITests.swift */; };
 		1D4D9C1325092F4A00348246 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4D9C1225092F4A00348246 /* CoreDataManager.swift */; };
 		1D4D9C17250930AB00348246 /* labs-ios-starter.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1D4D9C15250930AB00348246 /* labs-ios-starter.xcdatamodeld */; };
-		1DB156B22516B8C60084ECA0 /* TopicControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9983C5725141AC6001D91FE /* TopicControllerTests.swift */; };
+		1DB156B22516B8C60084ECA0 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		1DB3E114251A526D00A2F88F /* TopicCVSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB3E113251A526D00A2F88F /* TopicCVSections.swift */; };
 		463AD24324CF275900447BB8 /* ProfileDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463AD24224CF275900447BB8 /* ProfileDetailViewController.swift */; };
 		466C4274249A8748007D033E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466C4273249A8748007D033E /* AppDelegate.swift */; };
 		466C4276249A8748007D033E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466C4275249A8748007D033E /* SceneDelegate.swift */; };
@@ -116,6 +117,7 @@
 		1D4D9C0B25092B5400348246 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1D4D9C1225092F4A00348246 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		1D4D9C16250930AB00348246 /* labs-ios-starter.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "labs-ios-starter.xcdatamodel"; sourceTree = "<group>"; };
+		1DB3E113251A526D00A2F88F /* TopicCVSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicCVSections.swift; sourceTree = "<group>"; };
 		463AD24224CF275900447BB8 /* ProfileDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDetailViewController.swift; sourceTree = "<group>"; };
 		466C4270249A8748007D033E /* labs-ios-starter.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "labs-ios-starter.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		466C4273249A8748007D033E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -264,6 +266,7 @@
 			children = (
 				1D0E1054250AB35E00A21C44 /* Model Controllers */,
 				1D0E1055250AB36300A21C44 /* View Controllers */,
+				1DB3E112251A51E300A2F88F /* View Models */,
 				1D0E1056250AB37600A21C44 /* View */,
 			);
 			path = Surveys;
@@ -323,6 +326,14 @@
 				1D4D9C1225092F4A00348246 /* CoreDataManager.swift */,
 			);
 			path = Persistence;
+			sourceTree = "<group>";
+		};
+		1DB3E112251A51E300A2F88F /* View Models */ = {
+			isa = PBXGroup;
+			children = (
+				1DB3E113251A526D00A2F88F /* TopicCVSections.swift */,
+			);
+			path = "View Models";
 			sourceTree = "<group>";
 		};
 		465DAA2724BD0BC100D94C24 /* App Lifecycle */ = {
@@ -426,21 +437,6 @@
 				B91BF7EE250C47F600D68EA6 /* Profile.swift */,
 			);
 			path = "Okta Auth";
-			sourceTree = "<group>";
-		};
-		B91BF7E4250BC56E00D68EA6 /* CreateTopic */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = CreateTopic;
-			sourceTree = "<group>";
-		};
-		B91BF7E5250BC57700D68EA6 /* Feature-topic */ = {
-			isa = PBXGroup;
-			children = (
-				B91BF7E4250BC56E00D68EA6 /* CreateTopic */,
-			);
-			path = "Feature-topic";
 			sourceTree = "<group>";
 		};
 		B94042072501CE670048BCED /* View Controllers */ = {
@@ -562,7 +558,6 @@
 			children = (
 				B9404231250321230048BCED /* labs_ios_starterTests.swift */,
 				B9390BE6250991D300131227 /* NetworkServiceTests.swift */,
-				B9983C5725141AC6001D91FE /* TopicControllerTests.swift */,
 				B9404233250321230048BCED /* Info.plist */,
 			);
 			path = "labs-ios-starterTests";
@@ -732,6 +727,7 @@
 				1D0545292515C3BC006E8665 /* Topic+CoreDataProperties.swift in Sources */,
 				1D0545252515C3BC006E8665 /* Question+CoreDataProperties.swift in Sources */,
 				B940421A2501D1CE0048BCED /* UIViewController+Alerts.swift in Sources */,
+				1DB3E114251A526D00A2F88F /* TopicCVSections.swift in Sources */,
 				B9091EEF25183F2E009BA6A7 /* TopicCollectionViewCell.swift in Sources */,
 				46BEB4E924C98DAF00FE0CD1 /* ProfileListViewController.swift in Sources */,
 				B94042112501D0740048BCED /* ErrorHandler.swift in Sources */,
@@ -774,7 +770,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1DB156B22516B8C60084ECA0 /* TopicControllerTests.swift in Sources */,
+				1DB156B22516B8C60084ECA0 /* (null) in Sources */,
 				B9390BE7250991D300131227 /* NetworkServiceTests.swift in Sources */,
 				B9404232250321230048BCED /* labs_ios_starterTests.swift in Sources */,
 			);

--- a/labs-ios-starter/Application/Extensions/String + identifier.swift
+++ b/labs-ios-starter/Application/Extensions/String + identifier.swift
@@ -34,42 +34,53 @@ enum CollectionViewIdentifier: String {
     case crudCollectionViewCell = "CRUDCollectionViewCell"
 }
 
-extension String {
+enum CollectionViewHeaderId: String {
+    case topicSectionHeader
+}
 
-    ///convenience method to retrieve Storyboard Identifiers
+extension String {
+    /// convenience method to retrieve Storyboard Identifiers
     /// - Parameter identifier: defined in `enum StoryboardIdentifier` in String + identifier.swift
     /// - Returns: the rawValue of the case with the first letter capitalized
     static func getStoryboardID(_ identifier: StoryboardIdentifier) -> String {
-        //storyboard ids are capitalized
+        // storyboard ids are capitalized
         identifier.rawValue.firstCapitalized
     }
 
-    ///convenience method to get Segue Identifiers
+    /// convenience method to get Segue Identifiers
     /// - Parameter identifier: defined in `enum SegueIdentifier` in String + identifier.swift
     /// - Returns: the rawValue of the case with the first letter capitalized
     static func getSegueID(_ identifier: SegueIdentifier) -> String {
-        //segue ids are capitalized
+        // segue ids are capitalized
         identifier.rawValue.firstCapitalized
     }
 
-    ///convenience method to get TableView Identifiers
+    /// convenience method to get TableView Identifiers
     /// - Parameter identifier: defined in `enum TableViewIdentifier` in String + identifier.swift
     /// - Returns: the rawValue of the case with the first letter capitalized
     static func getTableViewCellID(_ identifier: TableViewIdentifier) -> String {
-        //tableView ids are capitalized
+        // tableView ids are capitalized
         identifier.rawValue.firstCapitalized
     }
 
-    ///convenience method to get CollectionView Identifiers
+    /// convenience method to get CollectionView Identifiers
     /// - Parameter identifier: defined in `enum CollectionViewIdentifier` in String + identifier.swift
     /// - Returns: the rawValue of the case with the first letter capitalized
     static func getCollectionViewCellID(_ identifier: CollectionViewIdentifier) -> String {
-        //collectionView ids are capitalized
+        // collectionView ids are capitalized
+        identifier.rawValue.firstCapitalized
+    }
+
+    /// convenience method to get CollectionView Header Identifiers
+    /// - Parameter identifier: defined in `enum CollectionViewHeaderId` in String + identifier.swift
+    /// - Returns: the rawValue of the case with the first letter capitalized
+    static func getCollectionViewHeaderId(_ identifier: CollectionViewHeaderId) -> String {
+        // collectionView ids are capitalized
         identifier.rawValue.firstCapitalized
     }
 }
 
 extension StringProtocol {
-    ///capitalize the first letter of the string without mutating the rest
+    /// capitalize the first letter of the string without mutating the rest
     var firstCapitalized: String { prefix(1).capitalized + dropFirst() }
 }

--- a/labs-ios-starter/Surveys/View Controllers/TopicViewController.swift
+++ b/labs-ios-starter/Surveys/View Controllers/TopicViewController.swift
@@ -4,11 +4,12 @@
 import UIKit
 
 class TopicViewController: UIViewController {
-    
     // MARK: - Outlets & Properties
-    @IBOutlet weak var topicsCollectionView: UICollectionView!
-    
-    let reuseIdentifier = String.getCollectionViewCellID(.topicsCollectionViewCell)
+
+    @IBOutlet var topicsCollectionView: UICollectionView!
+
+    let cellReuseIdentifier = String.getCollectionViewCellID(.topicsCollectionViewCell)
+    let headerReuseIdentifier = String.getCollectionViewHeaderId(.topicSectionHeader)
     let topicController = TopicController()
 
     var topics: [Topic]? {
@@ -24,7 +25,7 @@ class TopicViewController: UIViewController {
     }
 
     // MARK: - Lifecycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         topicController.fetchTopic { result in
@@ -34,7 +35,7 @@ class TopicViewController: UIViewController {
                     self.topics = topics
                 }
             case .failure(let error):
-                self.presentNetworkError(error: error.rawValue) { (tryAgain) in
+                self.presentNetworkError(error: error.rawValue) { tryAgain in
                     if let tryAgain = tryAgain {
                         if tryAgain {
                             // TODO:
@@ -46,44 +47,61 @@ class TopicViewController: UIViewController {
         }
     }
 
-
     // MARK: - Handlers
 
     // MARK: - Reusable
-
 }
 
-extension TopicViewController: UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        //TODO: Topics I'm a leader of vs topics I'm a member of (2 sections, or dynamic)
-        topics?.count ?? 0
+extension TopicViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return TopicCVSections.allCases.count
     }
-    
+
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        if let sectionHeader = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: headerReuseIdentifier, for: indexPath) as? TopicSectionHeader {
+            sectionHeader.sectionHeaderLabel.text = TopicCVSections(rawValue: indexPath.section)?.description
+            return sectionHeader
+        }
+        fatalError("Failed to configure collectionView header. Broken method or out of range.")
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        guard let section = TopicCVSections(rawValue: section) else { return 0 }
+        switch section {
+        case .leader: return topics?.count ?? 0 // TODO: frc.items in this section.count
+        case .member: return 0 // TODO: frc.items in this section.count
+        }
+    }
+
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = topicsCollectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as? TopicCollectionViewCell else {
+        guard let cell = topicsCollectionView.dequeueReusableCell(withReuseIdentifier: cellReuseIdentifier, for: indexPath) as? TopicCollectionViewCell else {
             fatalError("couldn't downcast TopicCollectionViewCell 🚨CHANGE THIS BEFORE PRODUCTION🚨")
         }
-
-        cell.topic = self.topics?[indexPath.row]
-        cell.setDimensions(width: view.frame.width - 40, height: 80)
-        return cell
+        guard let section = TopicCVSections(rawValue: indexPath.section) else {
+            fatalError("Section broken or out of range")
+        }
+        switch section {
+        case .leader, .member:
+            cell.topic = topics?[indexPath.row]
+            cell.setDimensions(width: view.frame.width - 40, height: 80)
+            return cell
+        }
     }
-    
 }
 
 // MARK: - Live Previews
 
 #if DEBUG
 
-import SwiftUI
+    import SwiftUI
 
-struct TopicViewControllerPreview: PreviewProvider {
-    static var previews: some View {
-        let storyboard = UIStoryboard(name: "Surveys", bundle: .main)
-        let tabBarController = storyboard.instantiateInitialViewController() as? UITabBarController
-        
-        return tabBarController?.view.livePreview.edgesIgnoringSafeArea(.all)
+    struct TopicViewControllerPreview: PreviewProvider {
+        static var previews: some View {
+            let storyboard = UIStoryboard(name: "Surveys", bundle: .main)
+            let tabBarController = storyboard.instantiateInitialViewController() as? UITabBarController
+
+            return tabBarController?.view.livePreview.edgesIgnoringSafeArea(.all)
+        }
     }
-}
 
 #endif

--- a/labs-ios-starter/Surveys/View Models/TopicCVSections.swift
+++ b/labs-ios-starter/Surveys/View Models/TopicCVSections.swift
@@ -1,15 +1,22 @@
 // Copyright © 2020 Shawn James. All rights reserved.
 // TopicCVSections.swift
 
+import UIKit
+
 /// Sets the sections headers for the collectionView on the TopicViewController. Order sensitive. Description is label text.
 enum TopicCVSections: Int, CaseIterable, CustomStringConvertible {
-    case myTopics
-    case joined
+    case leader
+    case member
     
     var description: String {
         switch self {
-            case .myTopics: return "My Topics"
-            case .joined: return "Advanced Settings"
+            case .leader: return "Leader"
+            case .member: return "Member"
         }
     }
+}
+
+/// This links with the storyboard to configure the cells appearance and make it reusable view.
+class TopicSectionHeader: UICollectionReusableView {
+    @IBOutlet var sectionHeaderLabel: UILabel!
 }

--- a/labs-ios-starter/Surveys/View Models/TopicCVSections.swift
+++ b/labs-ios-starter/Surveys/View Models/TopicCVSections.swift
@@ -1,0 +1,15 @@
+// Copyright © 2020 Shawn James. All rights reserved.
+// TopicCVSections.swift
+
+/// Sets the sections headers for the collectionView on the TopicViewController. Order sensitive. Description is label text.
+enum TopicCVSections: Int, CaseIterable, CustomStringConvertible {
+    case myTopics
+    case joined
+    
+    var description: String {
+        switch self {
+            case .myTopics: return "My Topics"
+            case .joined: return "Advanced Settings"
+        }
+    }
+}

--- a/labs-ios-starter/Surveys/View/Surveys.storyboard
+++ b/labs-ios-starter/Surveys/View/Surveys.storyboard
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="8G5-qa-L0a">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="8G5-qa-L0a">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -37,7 +35,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SurveyName JoinCode #12Aba2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Euh-wU-OmR">
-                                                    <rect key="frame" x="8" y="54" width="245.5" height="20.5"/>
+                                                    <rect key="frame" x="8" y="54" width="247" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -58,14 +56,14 @@
                                 </connections>
                             </collectionView>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="Bip-gd-9K3"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="X8O-Oy-TAe" firstAttribute="trailing" secondItem="Bip-gd-9K3" secondAttribute="trailing" id="7o2-rX-BmJ"/>
                             <constraint firstItem="X8O-Oy-TAe" firstAttribute="leading" secondItem="Bip-gd-9K3" secondAttribute="leading" id="fYu-H0-GIC"/>
                             <constraint firstItem="X8O-Oy-TAe" firstAttribute="bottom" secondItem="Bip-gd-9K3" secondAttribute="bottom" id="nWf-b3-e5U"/>
                             <constraint firstItem="X8O-Oy-TAe" firstAttribute="top" secondItem="Bip-gd-9K3" secondAttribute="top" id="rrG-Md-N3V"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="Bip-gd-9K3"/>
                     </view>
                     <navigationItem key="navigationItem" title="Notifications" id="aKX-yu-ofX"/>
                     <connections>
@@ -81,24 +79,24 @@
             <objects>
                 <viewController id="aZv-jt-onU" customClass="TopicDetailViewController" customModule="labs_ios_starter" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="R8Y-7V-T2F">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="6b0-Ru-Eek">
                                 <rect key="frame" x="275" y="20" width="119" height="30"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RYY-ub-M0S">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RYY-ub-M0S">
                                         <rect key="frame" x="0.0" y="0.0" width="45" height="30"/>
                                         <state key="normal" title="Delete"/>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="unT-m1-qpT">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="unT-m1-qpT">
                                         <rect key="frame" x="85" y="0.0" width="34" height="30"/>
                                         <state key="normal" title="Save"/>
                                     </button>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="968-NL-voA">
-                                <rect key="frame" x="20" y="20" width="47" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="968-NL-voA">
+                                <rect key="frame" x="20" y="20" width="48" height="30"/>
                                 <state key="normal" title="&lt; Back"/>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TopicName" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vsb-lY-OoI">
@@ -137,21 +135,21 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="124" translatesAutoresizingMaskIntoConstraints="NO" id="mJ7-Kx-xhe">
                                                     <rect key="frame" x="8" y="42" width="358" height="30"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1DI-1M-HoH">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1DI-1M-HoH">
                                                             <rect key="frame" x="0.0" y="0.0" width="46" height="30"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="46" id="pRo-Cw-lSe"/>
                                                             </constraints>
                                                             <state key="normal" title="Delete"/>
                                                         </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HTH-5w-WSd">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HTH-5w-WSd">
                                                             <rect key="frame" x="170" y="0.0" width="30" height="30"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="30" id="SC7-lE-KoW"/>
                                                             </constraints>
                                                             <state key="normal" title="Edit"/>
                                                         </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DQS-OF-7YW">
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DQS-OF-7YW">
                                                             <rect key="frame" x="324" y="0.0" width="34" height="30"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="34" id="JOz-KA-E62"/>
@@ -185,8 +183,7 @@
                                 </connections>
                             </collectionView>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="nvG-xm-u24"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="6b0-Ru-Eek" firstAttribute="top" secondItem="nvG-xm-u24" secondAttribute="top" constant="20" id="0TT-15-sMb"/>
                             <constraint firstAttribute="bottom" secondItem="55I-Py-9aA" secondAttribute="bottom" id="6SC-03-fuU"/>
@@ -200,6 +197,7 @@
                             <constraint firstItem="nvG-xm-u24" firstAttribute="trailing" secondItem="6b0-Ru-Eek" secondAttribute="trailing" constant="20" id="wIW-Aq-DGN"/>
                             <constraint firstItem="55I-Py-9aA" firstAttribute="top" secondItem="vsb-lY-OoI" secondAttribute="bottom" constant="20" id="wMi-Ec-xlr"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="nvG-xm-u24"/>
                     </view>
                     <navigationItem key="navigationItem" title="TopicName" id="hx3-yl-eRk"/>
                     <connections>
@@ -224,20 +222,20 @@
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="OVK-aE-KvM">
                                     <size key="itemSize" width="374" height="128"/>
                                     <size key="estimatedItemSize" width="374" height="128"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="headerReferenceSize" width="50" height="35"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="20" maxX="0.0" maxY="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="10" maxX="0.0" maxY="10"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="TopicsCollectionViewCell" id="wkv-Kr-u2R" customClass="TopicCollectionViewCell" customModule="labs_ios_starter" customModuleProvider="target">
-                                        <rect key="frame" x="20" y="20" width="374" height="80"/>
+                                        <rect key="frame" x="20" y="45" width="374" height="80"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="IUo-Ov-4Oj">
                                             <rect key="frame" x="0.0" y="0.0" width="374" height="80"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Topic Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IkA-BA-5Dw">
-                                                    <rect key="frame" x="8.5" y="25" width="90.5" height="30"/>
+                                                    <rect key="frame" x="8" y="25" width="91" height="30"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -268,6 +266,28 @@
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
+                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" reuseIdentifier="TopicSectionHeader" id="TFx-Qc-xKJ" customClass="TopicSectionHeader" customModule="labs_ios_starter" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="35"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dvA-bx-ri4">
+                                            <rect key="frame" x="16" y="6" width="382" height="23"/>
+                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="19"/>
+                                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <color key="backgroundColor" name="accent"/>
+                                    <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="trailingMargin" secondItem="dvA-bx-ri4" secondAttribute="trailing" constant="8" id="Djh-dk-Eaq"/>
+                                        <constraint firstItem="dvA-bx-ri4" firstAttribute="leading" secondItem="TFx-Qc-xKJ" secondAttribute="leadingMargin" constant="8" id="kjH-ts-6Lm"/>
+                                        <constraint firstItem="dvA-bx-ri4" firstAttribute="centerY" secondItem="TFx-Qc-xKJ" secondAttribute="centerY" id="nQs-Xr-ebc"/>
+                                    </constraints>
+                                    <connections>
+                                        <outlet property="sectionHeaderLabel" destination="dvA-bx-ri4" id="V9G-Ob-OCX"/>
+                                    </connections>
+                                </collectionReusableView>
                                 <connections>
                                     <outlet property="dataSource" destination="d5s-zH-Vqv" id="Eka-Tk-8Vm"/>
                                     <outlet property="delegate" destination="d5s-zH-Vqv" id="Jgd-4y-RHs"/>
@@ -285,8 +305,7 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="EyG-QQ-WFE"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="EyG-QQ-WFE" firstAttribute="trailing" secondItem="P4f-w5-Rxe" secondAttribute="trailing" constant="30" id="0H0-gF-Dcm"/>
                             <constraint firstItem="15c-Ri-lBV" firstAttribute="top" secondItem="EyG-QQ-WFE" secondAttribute="top" id="N4o-Am-ECy"/>
@@ -295,6 +314,7 @@
                             <constraint firstItem="15c-Ri-lBV" firstAttribute="leading" secondItem="EyG-QQ-WFE" secondAttribute="leading" id="rQ8-Gc-fm6"/>
                             <constraint firstItem="15c-Ri-lBV" firstAttribute="bottom" secondItem="EyG-QQ-WFE" secondAttribute="bottom" id="ujC-1O-RdF"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="EyG-QQ-WFE"/>
                     </view>
                     <navigationItem key="navigationItem" title="Topics" id="Nbf-zG-w68">
                         <barButtonItem key="rightBarButtonItem" image="person.circle.fill" catalog="system" id="Ojh-ir-s5z"/>
@@ -312,7 +332,7 @@
             <objects>
                 <viewController id="Qtl-Jb-c92" customClass="TopicNameViewController" customModule="labs_ios_starter" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="gbi-qB-SWx">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Placeholder..." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="GWP-JC-dNk">
@@ -329,7 +349,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2KR-hX-KIj" customClass="StandardButton" customModule="labs_ios_starter" customModuleProvider="target">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2KR-hX-KIj" customClass="StandardButton" customModule="labs_ios_starter" customModuleProvider="target">
                                 <rect key="frame" x="20" y="343" width="374" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="lyV-uv-a1g"/>
@@ -340,7 +360,6 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="z2S-2r-2ct"/>
                         <color key="backgroundColor" name="background"/>
                         <constraints>
                             <constraint firstItem="GWP-JC-dNk" firstAttribute="top" secondItem="aAf-6C-nBt" secondAttribute="bottom" constant="20" id="DO7-6k-dMr"/>
@@ -353,6 +372,7 @@
                             <constraint firstItem="aAf-6C-nBt" firstAttribute="leading" secondItem="z2S-2r-2ct" secondAttribute="leading" constant="20" id="nD0-rC-BAt"/>
                             <constraint firstItem="2KR-hX-KIj" firstAttribute="top" secondItem="GWP-JC-dNk" secondAttribute="bottom" constant="20" id="uPP-Tp-TUl"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="z2S-2r-2ct"/>
                     </view>
                     <navigationItem key="navigationItem" title="New Topic Name" id="Vma-tM-N9m"/>
                     <connections>
@@ -368,7 +388,7 @@
             <objects>
                 <viewController id="VRw-Ph-qHy" customClass="TopicQuestionsViewController" customModule="labs_ios_starter" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="NYf-KN-tmm">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="XSM-yT-fWX">
@@ -390,7 +410,7 @@
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="QuestionName?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VoP-Eq-9Y5">
-                                                    <rect key="frame" x="8" y="30" width="122" height="20.5"/>
+                                                    <rect key="frame" x="8" y="30" width="122.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -457,7 +477,7 @@
                                 </segments>
                                 <color key="selectedSegmentTintColor" name="action"/>
                             </segmentedControl>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WfL-uy-8gj" userLabel="Send Button" customClass="StandardButton" customModule="labs_ios_starter" customModuleProvider="target">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WfL-uy-8gj" userLabel="Send Button" customClass="StandardButton" customModule="labs_ios_starter" customModuleProvider="target">
                                 <rect key="frame" x="20" y="742" width="374" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="tED-wK-u22"/>
@@ -468,8 +488,7 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="pS7-9o-Fhm"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="pS7-9o-Fhm" firstAttribute="bottom" secondItem="WfL-uy-8gj" secondAttribute="bottom" constant="16" id="5Ej-eh-NiV"/>
                             <constraint firstItem="WfL-uy-8gj" firstAttribute="leading" secondItem="XSM-yT-fWX" secondAttribute="leading" constant="20" id="8T3-6L-QYZ"/>
@@ -482,6 +501,7 @@
                             <constraint firstItem="XSM-yT-fWX" firstAttribute="top" secondItem="adO-9K-PCb" secondAttribute="bottom" constant="8" id="da9-i5-s4x"/>
                             <constraint firstItem="WfL-uy-8gj" firstAttribute="top" secondItem="XSM-yT-fWX" secondAttribute="bottom" id="nTN-Tc-gWZ"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="pS7-9o-Fhm"/>
                     </view>
                     <navigationItem key="navigationItem" title="Questions" id="L5N-ZM-pFr"/>
                     <connections>
@@ -604,7 +624,7 @@
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="cell">
-            <color red="0.89011829219827354" green="0.93585979040957157" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.60399997234344482" green="0.26600000262260437" blue="1" alpha="0.14100000262260437" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
# [iOS - as a mobile user, I can view the topics I'm a member or leader of](https://trello.com/c/3wZFToEo/51-ios-as-a-mobile-user-i-can-view-the-topics-im-a-member-or-leader-of) 

## Changes
- Developers can safely add or update headers for collection view in topicViewController.
- Headers were implemented with styling, labels, and the model (from frc) is ready to be plugged in where TODO comments are to populate the sections. (Everything defaults to the top section in the meantime)

## Checklist
`choose one minimum`
- [ ] created unit test
- [ ] updated unit test
- [ ] created UI test
- [ ] updated UI test
- [x] bug fix/other

`required`
- [x] tested locally
- [x] updated the docs (https://github.com/Lambda-School-Labs/Labs26-Apollo-iOS-TeamA/blob/master/.github/documentation_standards.md)

`optional`
- [ ] added new dependencies


## Screenshots
![image](https://user-images.githubusercontent.com/57146228/93920049-9c175180-fcdc-11ea-9fba-54dcf11947ec.png)
![image](https://user-images.githubusercontent.com/57146228/93920008-8c980880-fcdc-11ea-86d6-eb6666bd3510.png)