### PR TITLE
Feature/get responses-get threads

### DIFF
--- a/labs-ios-starter/Application/Network/NetworkService.swift
+++ b/labs-ios-starter/Application/Network/NetworkService.swift
@@ -19,6 +19,7 @@ typealias CompleteWithString = (Result<String, ErrorHandler.NetworkError>) -> Vo
 typealias CompleteWithTopics = (Result<[Topic], ErrorHandler.NetworkError>) -> Void
 /// Completion Handler with Void .success and NetworkError .failure
 typealias CompleteWithNetworkError = (Result<Void, ErrorHandler.NetworkError>) -> Void
+typealias CompleteWithDataOrNetworkError = (Result<Data, ErrorHandler.NetworkError>) -> Void
 
 protocol NetworkLoader {
     func loadData(using request: URLRequest, with completion: @escaping URLCompletion)

--- a/labs-ios-starter/Surveys/View Controllers/TopicDetailViewController.swift
+++ b/labs-ios-starter/Surveys/View Controllers/TopicDetailViewController.swift
@@ -36,7 +36,14 @@ class TopicDetailViewController: UIViewController {
 
     var questions: [ContextQuestion]? {
         didSet {
-//             updateViews()
+            let ids = questions!.map { $0.id }
+            responses = topicController?.dummyResponses.filter { ids.contains($0.contextQuestionId) }
+        }
+    }
+
+    var responses: [ContextResponseObject]? {
+        didSet {
+            //self.responseCollectionView.reloadData()
         }
     }
 
@@ -106,7 +113,7 @@ extension TopicDetailViewController: UICollectionViewDataSource {
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return questions?.count ?? 0 // cell should be populated by responses instead
+        return responses?.count ?? 0 // cell should be populated by responses instead
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -114,6 +121,7 @@ extension TopicDetailViewController: UICollectionViewDataSource {
             // TODO: Remove before prod
             fatalError("invalid identifier: \(reuseIdentifier)")
         }
+        // TODO: Set with response instead of question
         cell.question = questions?[indexPath.item]
         cell.setDimensions(width: view.frame.width - 40, height: 80)
         return cell

--- a/labs-ios-starter/Surveys/View Controllers/TopicViewController.swift
+++ b/labs-ios-starter/Surveys/View Controllers/TopicViewController.swift
@@ -80,9 +80,9 @@ class TopicViewController: LoginViewController, NSFetchedResultsControllerDelega
             // TESTING, REMOVE
             let member = Member(id: "1", email: "1@1.com", firstName: "firstOne", lastName: "lastOne", avatarURL: URL(string: "http://www.url.com"))
             topic.addToMembers(member)
+            topicDetailViewController.topicController = topicController
             topicDetailViewController.id = topic.id
             topicDetailViewController.topic = topic
-            topicDetailViewController.topicController = topicController
             try? CoreDataManager.shared.saveContext()
         }
     }

--- a/labs-ios-starter/Surveys/View/Surveys.storyboard
+++ b/labs-ios-starter/Surveys/View/Surveys.storyboard
@@ -250,7 +250,7 @@
                     <connections>
                         <outlet property="contextLabel" destination="mZh-wh-a7e" id="W4b-oq-A2e"/>
                         <outlet property="joinCodeLabel" destination="ruW-fE-C56" id="fMW-eX-RYp"/>
-                        <outlet property="responseCollectionView" destination="55I-Py-9aA" id="Vi9-gQ-not"/>
+                        <outlet property="responseCollectionView" destination="55I-Py-9aA" id="ymR-GD-bFR"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ntp-fg-Bhh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
# Add backend methods to get and link ContextResponses to ContextQuestions and Threads to ContextResponses
⚠️ Threads have *not* been tested ⚠️ 

## Changes
- added common method to get components
- added method to get threads
- added method to get responses

## Checklist
`choose one minimum`
- [ ] created unit test
- [ ] updated unit test
- [ ] created UI test
- [ ] updated UI test
- [x] bug fix/other - testing not available due to Okta sign in

`required`
- [ ] tested locally
- [x] updated the docs (https://github.com/Lambda-School-Labs/Labs26-Apollo-iOS-TeamA/blob/master/.github/documentation_standards.md)